### PR TITLE
Add default value for account name & count to S3 resource

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -1,9 +1,16 @@
+data "aws_caller_identity" "current" {}
+
+
 data "aws_s3_bucket" "log_bucket" {
   bucket = "${var.log_bucket}"
 }
 
+locals {
+  account_name = "${length(var.account_name) > 0 ? var.account_name : data.aws_caller_identity.current.account_id}"
+}
+
 resource "aws_s3_bucket" "guard_duty_lists" {
-  bucket = "${var.account_name}-guardduty-lists"
+  bucket = "${local.account_name}-guardduty-lists"
 
   lifecycle {
     prevent_destroy = true

--- a/bucket.tf
+++ b/bucket.tf
@@ -10,6 +10,7 @@ locals {
 }
 
 resource "aws_s3_bucket" "guard_duty_lists" {
+  count  = "${(var.threat_intel_list_path == "") || (var.ip_set_list_path == "")  ? 0 : 1}"
   bucket = "${local.account_name}-guardduty-lists"
 
   lifecycle {
@@ -61,8 +62,8 @@ data "aws_iam_policy_document" "guard_duty_lists" {
     }
 
     resources = [
-      "${aws_s3_bucket.guard_duty_lists.arn}",
-      "${aws_s3_bucket.guard_duty_lists.arn}/*",
+      "${element(concat(aws_s3_bucket.guard_duty_lists.*.arn, list("")), 0)}",
+      "${element(concat(aws_s3_bucket.guard_duty_lists.*.arn, list("")), 0)}/*",
     ]
 
     sid = "DenyUnsecuredTransport"

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "aws_guardduty_detector" "master" {
 
 resource "aws_s3_bucket_object" "MyThreatIntelSet" {
   count  = "${var.threat_intel_list_path == "" ? 0 : 1}"
-  bucket = "${aws_s3_bucket.guard_duty_lists.id}"
+  bucket = "${element(concat(aws_s3_bucket.guard_duty_lists.*.arn, list("")), 0)}"
   key    = "MyThreatIntelSet.txt"
   source = "${var.threat_intel_list_path}"
   etag   = "${md5(file("${var.threat_intel_list_path}"))}"
@@ -21,7 +21,7 @@ resource "aws_guardduty_threatintelset" "MyThreatIntelSet" {
 
 resource "aws_s3_bucket_object" "MyIPSet" {
   count  = "${var.ip_set_list_path == "" ? 0 : 1}"
-  bucket = "${aws_s3_bucket.guard_duty_lists.id}"
+  bucket = "${element(concat(aws_s3_bucket.guard_duty_lists.*.arn, list("")), 0)}"
   key    = "MyIPSet.txt"
   source = "${var.ip_set_list_path}"
   etag   = "${md5(file("${var.ip_set_list_path}"))}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "account_name" {
-  description = "The account name. Used to as a prefix to name resources."
+  description = "The account name. Used as a prefix to name resources."
   type        = "string"
+  default     = ""
 }
 
 variable "enable" {


### PR DESCRIPTION
Added ability to set account_name automatically to avoid needing to set parameter.
Added count to s3_bucket_resource as only needed if using IPSets or Threat Lists.